### PR TITLE
Enable VR DLSS preset selection

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -199,12 +199,6 @@ void Upscaling::DrawSettings()
 
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
 			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
-
-			if (globals::game::isVR) {
-				ImGui::Text("VR DLSS presets adjust the per-eye render resolution.");
-				ImGui::BulletText("DLAA keeps the native resolution with DLSS anti-aliasing.");
-				ImGui::BulletText("Quality, Balanced, Performance, and Ultra Performance progressively lower the render resolution for more performance.");
-			}
 		} else {
 			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
 		}

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -194,19 +194,16 @@ void Upscaling::DrawSettings()
 		const char* upscalePresetsDLSS[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "DLAA" };
 		const char* upscalePresets[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "Native AA" };
 
-		uint32_t qualityMax = globals::game::isVR ? 0u : 4u;
-		settings.qualityMode = std::clamp(settings.qualityMode, 0u, qualityMax);
+                uint32_t qualityMax = 4u;
+                settings.qualityMode = std::clamp(settings.qualityMode, 0u, qualityMax);
 
-		if (upscaleMethod == UpscaleMethod::kDLSS)
-			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
-		else
-			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
-	}
+                if (upscaleMethod == UpscaleMethod::kDLSS)
+                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
+                else
+                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
+        }
 
-	if (!globals::game::isVR)
-		ImGui::Text("Upscaling from lower resolutions is not currently available for VR");
-
-	if (!globals::game::isVR) {
+        if (!globals::game::isVR) {
 		if (ImGui::TreeNodeEx("Frame Generation", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::Text("Frame Generation interpolates real frames with generated ones for a smoother experience");
 			ImGui::Text("Uses AMD FSR Frame Generation technology");

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -197,11 +197,10 @@ void Upscaling::DrawSettings()
 		uint32_t qualityMax = 4u;
 		settings.qualityMode = std::clamp(settings.qualityMode, 0u, qualityMax);
 
-		if (upscaleMethod == UpscaleMethod::kDLSS) {
-			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
-		} else {
-			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
-		}
+                if (upscaleMethod == UpscaleMethod::kDLSS)
+                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
+                else
+                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
 	}
 
 	if (!globals::game::isVR) {

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -194,16 +194,23 @@ void Upscaling::DrawSettings()
 		const char* upscalePresetsDLSS[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "DLAA" };
 		const char* upscalePresets[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "Native AA" };
 
-                uint32_t qualityMax = 4u;
-                settings.qualityMode = std::clamp(settings.qualityMode, 0u, qualityMax);
+		uint32_t qualityMax = 4u;
+		settings.qualityMode = std::clamp(settings.qualityMode, 0u, qualityMax);
 
-                if (upscaleMethod == UpscaleMethod::kDLSS)
-                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
-                else
-                        ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
-        }
+		if (upscaleMethod == UpscaleMethod::kDLSS) {
+			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
 
-        if (!globals::game::isVR) {
+			if (globals::game::isVR) {
+				ImGui::Text("VR DLSS presets adjust the per-eye render resolution.");
+				ImGui::BulletText("DLAA keeps the native resolution with DLSS anti-aliasing.");
+				ImGui::BulletText("Quality, Balanced, Performance, and Ultra Performance progressively lower the render resolution for more performance.");
+			}
+		} else {
+			ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, static_cast<int>(qualityMax), std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
+		}
+	}
+
+	if (!globals::game::isVR) {
 		if (ImGui::TreeNodeEx("Frame Generation", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::Text("Frame Generation interpolates real frames with generated ones for a smoother experience");
 			ImGui::Text("Uses AMD FSR Frame Generation technology");


### PR DESCRIPTION
## Summary
- allow VR builds to keep the user-selected DLSS preset instead of forcing DLAA
- confirmed the VR upscaling path uses the chosen preset when querying Streamline for the render resolution scale
- removed the VR-specific tooltip block so the panel no longer shows redundant preset guidance in VR

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd08a0cdc832d890eee101fd7c1f9