### PR TITLE
fix: handle Streamline viewport comparison without constexpr

### DIFF
--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -1,5 +1,8 @@
 #include "Streamline.h"
 
+#include <cstring>
+#include <type_traits>
+
 #include <dxgi.h>
 #include <dxgi1_3.h>
 
@@ -9,6 +12,29 @@
 #include "../../Util.h"
 #include "../Upscaling.h"
 #include "DX12SwapChain.h"
+
+namespace
+{
+static_assert(std::is_trivially_copyable_v<sl::ViewportHandle>);
+
+[[nodiscard]] bool AreViewportHandlesEqual(const sl::ViewportHandle& lhs, const sl::ViewportHandle& rhs) noexcept
+{
+	const sl::ViewportHandle kEmpty{};
+
+	const bool lhsEmpty = std::memcmp(&lhs, &kEmpty, sizeof(kEmpty)) == 0;
+	const bool rhsEmpty = std::memcmp(&rhs, &kEmpty, sizeof(kEmpty)) == 0;
+
+	if (lhsEmpty && rhsEmpty) {
+		return true;
+	}
+
+	if (lhsEmpty != rhsEmpty) {
+		return false;
+	}
+
+	return std::memcmp(&lhs, &rhs, sizeof(sl::ViewportHandle)) == 0;
+}
+}
 
 void LoggingCallback(sl::LogType type, const char* msg)
 {
@@ -390,6 +416,10 @@ float Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputH
  */
 void Streamline::DestroyDLSSResources()
 {
+	if (AreViewportHandlesEqual(viewport, sl::ViewportHandle{})) {
+		return;
+	}
+
 	sl::DLSSOptions dlssOptions{};
 	dlssOptions.mode = sl::DLSSMode::eOff;
 	slDLSSSetOptions(viewport, dlssOptions);


### PR DESCRIPTION
## Summary
- replace the compile-time empty viewport handle with a runtime-constructed helper and accompanying comparisons
- skip DLSS teardown calls when the stored viewport handle is empty to avoid redundant Streamline work
- drop the anonymous-namespace closing comment to match the surrounding style expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d02e977118832dbac8823ba13d49b7