### PR TITLE
Align Streamline resource allocation with SDK API

### DIFF
--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -41,129 +41,7 @@ static_assert(std::is_trivially_copyable_v<sl::ViewportHandle>);
 	return std::memcmp(&lhs, &rhs, sizeof(sl::ViewportHandle)) == 0;
 }
 
-template <class T>
-inline constexpr bool dependent_false_v = false;
 
-template <class AllocateFunc>
-sl::Result InvokeAllocateResources(AllocateFunc func, sl::Feature feature, sl::ViewportHandle& viewport)
-{
-    // Streamline has shipped multiple variations of the resource allocation entry point.
-    // Probe a set of known signatures so we remain compatible with SDK updates.
-    sl::ViewportHandle* viewportPtr = &viewport;
-
-    if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle&>) {
-        return func(feature, viewport);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle*, uint32_t>) {
-        return func(feature, &viewport, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, uint32_t, sl::ViewportHandle*>) {
-        return func(feature, 1u, &viewport);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle**, uint32_t>) {
-        return func(feature, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, uint32_t, sl::ViewportHandle**>) {
-        return func(feature, 1u, &viewportPtr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle*, uint32_t>) {
-        return func(feature, nullptr, &viewport, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle*>) {
-        return func(feature, nullptr, 1u, &viewport);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle*, uint32_t, std::nullptr_t>) {
-        return func(feature, &viewport, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle*, std::nullptr_t, uint32_t>) {
-        return func(feature, &viewport, nullptr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle*, std::nullptr_t>) {
-        return func(feature, nullptr, &viewport, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, std::nullptr_t, sl::ViewportHandle*>) {
-        return func(feature, nullptr, nullptr, &viewport);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle**, uint32_t>) {
-        return func(feature, nullptr, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle**>) {
-        return func(feature, nullptr, 1u, &viewportPtr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle**, uint32_t, std::nullptr_t>) {
-        return func(feature, &viewportPtr, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle**, std::nullptr_t, uint32_t>) {
-        return func(feature, &viewportPtr, nullptr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle**, std::nullptr_t>) {
-        return func(feature, nullptr, &viewportPtr, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, std::nullptr_t, sl::ViewportHandle**>) {
-        return func(feature, nullptr, nullptr, &viewportPtr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle*, uint32_t>) {
-        return func(feature, nullptr, 0u, &viewport, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle**, uint32_t>) {
-        return func(feature, nullptr, 0u, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, uint32_t, std::nullptr_t, sl::ViewportHandle*, uint32_t>) {
-        return func(feature, 0u, nullptr, &viewport, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, uint32_t, std::nullptr_t, sl::ViewportHandle**, uint32_t>) {
-        return func(feature, 0u, nullptr, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle*, uint32_t, std::nullptr_t, uint32_t>) {
-        return func(feature, &viewport, 1u, nullptr, 0u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle**, uint32_t, std::nullptr_t, uint32_t>) {
-        return func(feature, &viewportPtr, 1u, nullptr, 0u);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle*, uint32_t, std::nullptr_t>) {
-        return func(feature, nullptr, &viewport, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle**, uint32_t, std::nullptr_t>) {
-        return func(feature, nullptr, &viewportPtr, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle*, uint32_t, std::nullptr_t>) {
-        return func(feature, nullptr, 0u, &viewport, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle**, uint32_t, std::nullptr_t>) {
-        return func(feature, nullptr, 0u, &viewportPtr, 1u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle*, uint32_t, std::nullptr_t, uint32_t, std::nullptr_t>) {
-        return func(feature, &viewport, 1u, nullptr, 0u, nullptr);
-    } else if constexpr (std::is_invocable_r_v<sl::Result, AllocateFunc, sl::Feature, sl::ViewportHandle**, uint32_t, std::nullptr_t, uint32_t, std::nullptr_t>) {
-        return func(feature, &viewportPtr, 1u, nullptr, 0u, nullptr);
-    } else {
-        static_assert(dependent_false_v<AllocateFunc>, "Unsupported slAllocateResources signature");
-    }
-}
-
-template <class FreeFunc>
-void InvokeFreeResources(FreeFunc func, sl::Feature feature, sl::ViewportHandle& viewport)
-{
-    // slFreeResources follows the same evolution as slAllocateResources; handle the observed variants.
-    sl::ViewportHandle* viewportPtr = &viewport;
-
-    if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle&>) {
-        func(feature, viewport);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle*, uint32_t>) {
-        func(feature, &viewport, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, uint32_t, sl::ViewportHandle*>) {
-        func(feature, 1u, &viewport);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle**>) {
-        func(feature, &viewportPtr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle**, uint32_t>) {
-        func(feature, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle*>) {
-        func(feature, nullptr, &viewport);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle*>) {
-        func(feature, nullptr, 1u, &viewport);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle*, std::nullptr_t>) {
-        func(feature, &viewport, nullptr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle*, std::nullptr_t, uint32_t>) {
-        func(feature, &viewport, nullptr, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle*, std::nullptr_t>) {
-        func(feature, nullptr, &viewport, nullptr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, std::nullptr_t, sl::ViewportHandle*>) {
-        func(feature, nullptr, nullptr, &viewport);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle**, uint32_t>) {
-        func(feature, nullptr, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle**>) {
-        func(feature, nullptr, 1u, &viewportPtr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle**, uint32_t, std::nullptr_t>) {
-        func(feature, &viewportPtr, 1u, nullptr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle**, std::nullptr_t, uint32_t>) {
-        func(feature, &viewportPtr, nullptr, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, sl::ViewportHandle**, std::nullptr_t>) {
-        func(feature, nullptr, &viewportPtr, nullptr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, std::nullptr_t, sl::ViewportHandle**>) {
-        func(feature, nullptr, nullptr, &viewportPtr);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, std::nullptr_t, uint32_t, sl::ViewportHandle**, uint32_t>) {
-        func(feature, nullptr, 0u, &viewportPtr, 1u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle*, uint32_t, std::nullptr_t, uint32_t>) {
-        func(feature, &viewport, 1u, nullptr, 0u);
-    } else if constexpr (std::is_invocable_v<FreeFunc, sl::Feature, sl::ViewportHandle**, uint32_t, std::nullptr_t, uint32_t>) {
-        func(feature, &viewportPtr, 1u, nullptr, 0u);
-    } else {
-        static_assert(dependent_false_v<FreeFunc>, "Unsupported slFreeResources signature");
-    }
-}
 }
 
 void LoggingCallback(sl::LogType type, const char* msg)
@@ -648,14 +526,14 @@ void Streamline::DestroyDLSSResources()
 			continue;
 		}
 
-        slDLSSSetOptions(eye.viewport, dlssOptions);
-        if (slFreeResources != nullptr) {
-            InvokeFreeResources(slFreeResources, sl::kFeatureDLSS, eye.viewport);
-        } else {
-            logger::warn("[Streamline] slFreeResources unavailable while releasing viewport {}", eyeIndex);
-        }
-        ResetEyeState(eyeIndex);
-    }
+		slDLSSSetOptions(eye.viewport, dlssOptions);
+		if (slFreeResources != nullptr) {
+			slFreeResources(sl::kFeatureDLSS, eye.viewport);
+		} else {
+			logger::warn("[Streamline] slFreeResources unavailable while releasing viewport {}", eyeIndex);
+		}
+		ResetEyeState(eyeIndex);
+	}
 }
 
 bool Streamline::EnsureViewportAllocated(uint32_t eyeIndex)
@@ -673,15 +551,20 @@ bool Streamline::EnsureViewportAllocated(uint32_t eyeIndex)
 		return false;
 	}
 
-    const sl::Result result = InvokeAllocateResources(slAllocateResources, sl::kFeatureDLSS, eye.viewport);
-    if (result != sl::Result::eOk) {
-        logger::error("[Streamline] Failed to allocate viewport {} (error: {})", eyeIndex, magic_enum::enum_name(result));
-        ResetEyeState(eyeIndex);
-        return false;
-    }
+	if (!IsViewportAllocated(eye.viewport)) {
+		// Streamline expects the caller to provide a unique, non-zero viewport handle identifier.
+		eye.viewport = sl::ViewportHandle(eyeIndex + 1u);
+		}
 
-    eye.constantsInitialized = false;
-    return true;
+	const sl::Result result = slAllocateResources(globals::d3d::context, sl::kFeatureDLSS, eye.viewport);
+	if (result != sl::Result::eOk) {
+		logger::error("[Streamline] Failed to allocate viewport {} (error: {})", eyeIndex, magic_enum::enum_name(result));
+		ResetEyeState(eyeIndex);
+		return false;
+	}
+
+	eye.constantsInitialized = false;
+	return true;
 }
 
 void Streamline::ResetEyeState(uint32_t eyeIndex)


### PR DESCRIPTION
## Summary
- remove the guessed Streamline resource allocation/freeing shims and rely on the official SDK signatures
- assign deterministic viewport handles and pass the D3D11 context when allocating Streamline resources

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d45195a1dc832dac3cf2c50d573fc6