### PR TITLE
docs: record upstream sync status

### DIFF
--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,0 +1,8 @@
+# Upstream sync status
+
+The fork's `dev` branch has been synchronized with [`doodlum/skyrim-community-shaders@dev`](https://github.com/doodlum/skyrim-community-shaders/tree/dev).
+
+- **Upstream commit:** `beed579b0746aa84fdd2e1cd405328cc14a206fa`
+- **Sync strategy:** Prefers upstream changes when resolving conflicts.
+- **Verification:** `git log -1` confirms the branch tip matches the upstream commit authored by doodlum ("fix: fix some internal errors when debugging (#1500)").
+- **Date of sync:** 2025-09-26T14:57:16Z UTC


### PR DESCRIPTION
## Summary
- document that the dev branch is synchronized with doodlum/dev and note the strategy used when resolving conflicts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a518b964832d867c63b2f56d0ec6