### PR TITLE
Refine dynamic resolution lock handling

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -9,6 +9,15 @@
 #include "Upscaling/XeSS.h"
 #include <Windows.h>
 #include <algorithm>
+
+namespace
+{
+    [[nodiscard]] bool ShouldLockDynamicResolution(const float2& scale)
+    {
+        constexpr float kLockThreshold = 0.9999f;
+        return scale.x >= kLockThreshold && scale.y >= kLockThreshold;
+    }
+}
 #include <directx/d3dx12.h>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
@@ -738,9 +747,8 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	dynamicResolutionWidthRatio = resolutionScale.x;
 	dynamicResolutionHeightRatio = resolutionScale.y;
 
-	// Disable dynamic resolution unless the game explictly enables it
-	if (!globals::game::isVR)
-		runtimeData.dynamicResolutionLock = 1;
+    // Keep the ratios adjustable whenever we are actually rendering at a reduced resolution.
+    runtimeData.dynamicResolutionLock = ShouldLockDynamicResolution(resolutionScale);
 }
 
 void Upscaling::SetupResources()
@@ -1502,8 +1510,8 @@ void Upscaling::PerformUpscaling()
 
 	auto& runtimeData = globals::game::graphicsState->GetRuntimeData();
 
-	// Disable dynamic resolution past this point
-	runtimeData.dynamicResolutionLock = 1;
+    // Keep the lock engaged only when we are effectively running at native resolution.
+    runtimeData.dynamicResolutionLock = ShouldLockDynamicResolution(resolutionScale);
 
 	// Updates the PerFrame constant buffer so that dynamic resolution settings are disabled
 	UpdateCameraData();


### PR DESCRIPTION
## Summary
- adjust the dynamic-resolution lock helper to treat scales below native resolution as unlocked with a tolerance around 1.0
- continue leaving the dynamic-resolution lock open whenever reduced render sizes are requested so both flat and VR passes see the scaled ratios

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da39ee6878832d87141ac749390c9d