### PR TITLE
Derive compute dispatch counts from shader metadata

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -423,8 +423,6 @@ void Deferred::DeferredPasses()
 
 	auto& ibl = globals::features::ibl;
 
-	auto dispatchCount = Util::GetScreenDispatchCount(true);
-
 	if (ssgi.loaded) {
 		// Ambient Composite
 		{
@@ -448,6 +446,7 @@ void Deferred::DeferredPasses()
 			context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 
 			auto shader = interior ? GetComputeAmbientCompositeInterior() : GetComputeAmbientComposite();
+			auto dispatchCount = Util::GetScreenDispatchCount(shader, true);
 			context->CSSetShader(shader, nullptr, 0);
 
 			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
@@ -506,6 +505,7 @@ void Deferred::DeferredPasses()
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
 		auto shader = interior ? GetComputeMainCompositeInterior() : GetComputeMainComposite();
+		auto dispatchCount = Util::GetScreenDispatchCount(shader, true);
 		context->CSSetShader(shader, nullptr, 0);
 
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -204,9 +204,6 @@ void SubsurfaceScattering::DrawSSS()
 	TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering");
 
 	validMaterials = false;
-
-	auto dispatchCount = Util::GetScreenDispatchCount();
-
 	{
 		auto cameraData = Util::GetCameraData(0);
 
@@ -257,6 +254,7 @@ void SubsurfaceScattering::DrawSSS()
 				TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Horizontal");
 
 				auto shader = GetComputeShaderHorizontalBlur();
+				auto dispatchCount = Util::GetScreenDispatchCount(shader);
 				context->CSSetShader(shader, nullptr, 0);
 
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
@@ -276,6 +274,7 @@ void SubsurfaceScattering::DrawSSS()
 				context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 
 				auto shader = GetComputeShaderVerticalBlur();
+				auto dispatchCount = Util::GetScreenDispatchCount(shader);
 				context->CSSetShader(shader, nullptr, 0);
 
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
@@ -286,6 +285,7 @@ void SubsurfaceScattering::DrawSSS()
 				TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Burley");
 
 				auto shader = GetComputeShaderBurley();
+				auto dispatchCount = Util::GetScreenDispatchCount(shader);
 				context->CSSetShader(shader, nullptr, 0);
 
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -152,8 +152,6 @@ void TerrainBlending::BlendPrepassDepths()
 	auto context = globals::d3d::context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);
 
-	auto dispatchCount = Util::GetScreenDispatchCount();
-
 	{
 		ID3D11ShaderResourceView* views[2] = { depthSRVBackup, terrainDepth.depthSRV };
 		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
@@ -161,7 +159,9 @@ void TerrainBlending::BlendPrepassDepths()
 		ID3D11UnorderedAccessView* uavs[2] = { blendedDepthTexture->uav.get(), blendedDepthTexture16->uav.get() };
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-		context->CSSetShader(GetDepthBlendShader(), nullptr, 0);
+		auto depthBlendShader = GetDepthBlendShader();
+		auto dispatchCount = Util::GetScreenDispatchCount(depthBlendShader);
+		context->CSSetShader(depthBlendShader, nullptr, 0);
 
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 	}

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1356,8 +1356,6 @@ void Upscaling::Upscale()
 
 	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
 
-	auto dispatchCount = Util::GetScreenDispatchCount(true);
-
 	{
 		state->BeginPerfEvent("Encode Upscaling Textures");
 
@@ -1409,7 +1407,9 @@ void Upscaling::Upscale()
 			ID3D11UnorderedAccessView* uavs[3] = { reactiveMaskUAV, transparencyUAV, motionVectorUAV };
 			context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-			context->CSSetShader(GetEncodeTexturesCS(), nullptr, 0);
+			auto encodeShader = GetEncodeTexturesCS();
+			auto dispatchCount = Util::GetScreenDispatchCount(encodeShader, true);
+			context->CSSetShader(encodeShader, nullptr, 0);
 
 			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 		}

--- a/src/Utils/D3D.cpp
+++ b/src/Utils/D3D.cpp
@@ -5,6 +5,39 @@
 
 #include <d3dcompiler.h>
 #include <mutex>
+#include <wrl/client.h>
+
+namespace
+{
+	constexpr GUID kComputeThreadGroupSizeGuid =
+	        { 0x7ea0399b, 0x7b2d, 0x41f1, 0x9d, 0x4d, 0x2c, 0x9b, 0xf2, 0x1a, 0x55, 0x7a };
+
+	struct ThreadGroupSizeData
+	{
+		std::uint32_t x;
+		std::uint32_t y;
+		std::uint32_t z;
+	};
+
+	void StoreComputeThreadGroupSize(ID3D11ComputeShader* shader, ID3DBlob* shaderBlob)
+	{
+		if (!shader || !shaderBlob)
+			return;
+
+		Microsoft::WRL::ComPtr<ID3D11ShaderReflection> reflector;
+		if (FAILED(D3DReflect(shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(),
+		                IID_PPV_ARGS(reflector.GetAddressOf())))) {
+			return;
+		}
+
+		D3D11_SHADER_DESC desc{};
+		if (FAILED(reflector->GetDesc(&desc)))
+			return;
+
+		ThreadGroupSizeData data{ desc.ThreadGroupSizeX, desc.ThreadGroupSizeY, desc.ThreadGroupSizeZ };
+		shader->SetPrivateData(kComputeThreadGroupSizeGuid, sizeof(data), &data);
+	}
+}  // namespace
 
 namespace Util
 {
@@ -207,17 +240,32 @@ namespace Util
 			ID3D11DomainShader* regShader;
 			device->CreateDomainShader(shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(), nullptr, &regShader);
 			return regShader;
-		} else if (!_stricmp(ProgramType, "cs_5_0")) {
+		} else if (!_stricmp(ProgramType, "cs_5_0") || !_stricmp(ProgramType, "cs_4_0")) {
 			ID3D11ComputeShader* regShader;
 			DX::ThrowIfFailed(device->CreateComputeShader(shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(), nullptr, &regShader));
-			return regShader;
-		} else if (!_stricmp(ProgramType, "cs_4_0")) {
-			ID3D11ComputeShader* regShader;
-			DX::ThrowIfFailed(device->CreateComputeShader(shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(), nullptr, &regShader));
+			StoreComputeThreadGroupSize(regShader, shaderBlob);
 			return regShader;
 		}
 
 		return nullptr;
+	}
+
+	ThreadGroupSize GetComputeThreadGroupSize(ID3D11ComputeShader* shader)
+	{
+		ThreadGroupSize size{ 8u, 8u, 1u };
+
+		if (!shader)
+			return size;
+
+		ThreadGroupSizeData data{};
+		UINT dataSize = sizeof(data);
+		if (SUCCEEDED(shader->GetPrivateData(kComputeThreadGroupSizeGuid, &dataSize, &data)) && dataSize == sizeof(data)) {
+			size.x = data.x != 0 ? data.x : size.x;
+			size.y = data.y != 0 ? data.y : size.y;
+			size.z = data.z != 0 ? data.z : size.z;
+		}
+
+		return size;
 	}
 
 	// RAII wrapper for D3D mapped resources

--- a/src/Utils/D3D.h
+++ b/src/Utils/D3D.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <array>
+#include <cstdint>
 #include <d3d11.h>
+#include <vector>
 
 namespace Util
 {
@@ -11,6 +13,15 @@ namespace Util
 	void SetResourceName(ID3D11DeviceChild* Resource, const char* Format, ...);
 
 	ID3D11DeviceChild* CompileShader(const wchar_t* FilePath, const std::vector<std::pair<const char*, const char*>>& Defines, const char* ProgramType, const char* Program = "main");
+	struct ThreadGroupSize
+	{
+		std::uint32_t x;
+		std::uint32_t y;
+		std::uint32_t z;
+	};
+
+	ThreadGroupSize GetComputeThreadGroupSize(ID3D11ComputeShader* shader);
+
 
 	// Texture manipulation utilities
 	void ApplyHighlightTintToTexture(ID3D11Texture2D* texture, bool isHighlighted, const std::array<float, 4>& highlightColor = { 1.0f, 0.5f, 0.0f, 0.3f });

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -1,5 +1,6 @@
 #include "Game.h"
 
+#include "D3D.h"
 #include "State.h"
 
 namespace Util
@@ -162,15 +163,20 @@ namespace Util
 			a_size.y * runtimeData.dynamicResolutionHeightRatio);
 	}
 
-	DispatchCount GetScreenDispatchCount(bool a_dynamic)
+	DispatchCount GetScreenDispatchCount(ID3D11ComputeShader* a_shader, bool a_dynamic)
 	{
 		float2 resolution = globals::state->screenSize;
 
-		if (a_dynamic)
-			ConvertToDynamic(resolution);
+		if (a_dynamic) {
+			resolution = ConvertToDynamic(resolution);
+		}
 
-		uint dispatchX = (uint)std::ceil(resolution.x / 8.0f);
-		uint dispatchY = (uint)std::ceil(resolution.y / 8.0f);
+		auto groupSize = GetComputeThreadGroupSize(a_shader);
+		const float groupWidth = groupSize.x > 0 ? static_cast<float>(groupSize.x) : 8.0f;
+		const float groupHeight = groupSize.y > 0 ? static_cast<float>(groupSize.y) : 8.0f;
+
+		uint dispatchX = static_cast<uint>(std::ceil(resolution.x / groupWidth));
+		uint dispatchY = static_cast<uint>(std::ceil(resolution.y / groupHeight));
 
 		return { dispatchX, dispatchY };
 	}

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -119,7 +119,7 @@ namespace Util
 		uint x;
 		uint y;
 	};
-	DispatchCount GetScreenDispatchCount(bool a_dynamic = true);
+	DispatchCount GetScreenDispatchCount(ID3D11ComputeShader* a_shader = nullptr, bool a_dynamic = true);
 
 	/**
 	 * @brief Checks if dynamic resolution is currently enabled.


### PR DESCRIPTION
## Summary
- record each compute shader's thread-group dimensions during compilation and expose a helper to query them later
- update the shared dispatch helper to accept an optional shader handle and size dispatches based on the reflected thread-group metadata
- switch deferred, subsurface scattering, terrain blending, and upscaling passes to request dispatch counts with their active compute shaders instead of assuming 8x8 groups

## Testing
- not run (platform-specific tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68da38241d08832db1d58abe4d0d202c