### PR TITLE
Set compute thread group fallback to 8x8x1

### DIFF
--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -159,9 +159,9 @@ void TerrainBlending::BlendPrepassDepths()
 		ID3D11UnorderedAccessView* uavs[2] = { blendedDepthTexture->uav.get(), blendedDepthTexture16->uav.get() };
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-		auto depthBlendShader = GetDepthBlendShader();
-		auto dispatchCount = Util::GetScreenDispatchCount(depthBlendShader);
-		context->CSSetShader(depthBlendShader, nullptr, 0);
+		auto depthBlendComputeShader = GetDepthBlendShader();
+		auto dispatchCount = Util::GetScreenDispatchCount(depthBlendComputeShader);
+		context->CSSetShader(depthBlendComputeShader, nullptr, 0);
 
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 	}

--- a/src/Utils/D3D.cpp
+++ b/src/Utils/D3D.cpp
@@ -3,6 +3,7 @@
 #include "State.h"
 #include "Utils/Format.h"
 
+#include <d3d11shader.h>
 #include <d3dcompiler.h>
 #include <mutex>
 #include <wrl/client.h>
@@ -30,11 +31,12 @@ namespace
 			return;
 		}
 
-		D3D11_SHADER_DESC desc{};
-		if (FAILED(reflector->GetDesc(&desc)))
-			return;
-
-		ThreadGroupSizeData data{ desc.ThreadGroupSizeX, desc.ThreadGroupSizeY, desc.ThreadGroupSizeZ };
+		ThreadGroupSizeData data{ 8u, 8u, 1u };
+		if (SUCCEEDED(reflector->GetThreadGroupSize(&data.x, &data.y, &data.z))) {
+			data.x = data.x != 0 ? data.x : 8u;
+			data.y = data.y != 0 ? data.y : 8u;
+			data.z = data.z != 0 ? data.z : 1u;
+		}
 		shader->SetPrivateData(kComputeThreadGroupSizeGuid, sizeof(data), &data);
 	}
 }  // namespace


### PR DESCRIPTION
## Summary
- default compute shader thread group metadata to 8x8x1 so old behavior is preserved when reflection fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfe647f90832db96b6163f224b5d6