### PR TITLE
Add developer gaze overlay debug toggle

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -25,10 +25,11 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	upscaleMethod,
 	upscaleMethodNoDLSS,
 	qualityMode,
-	frameLimitMode,
-	frameGenerationMode,
-	frameGenerationForceEnable,
-	streamlineLogLevel);
+        frameLimitMode,
+        frameGenerationMode,
+        frameGenerationForceEnable,
+        streamlineLogLevel,
+        debugShowGazeOverlay);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -281,52 +282,57 @@ void Upscaling::DrawSettings()
 		}
 	}
 
-	if (ImGui::TreeNodeEx("Backend Diagnostics")) {
-		// Streamline log level selection
-		const char* logLevels[] = { "Off", "Default", "Verbose" };
-		int logLevelIdx = static_cast<int>(settings.streamlineLogLevel);
-		if (ImGui::Combo("Streamline Logging", &logLevelIdx, logLevels, IM_ARRAYSIZE(logLevels))) {
-			settings.streamlineLogLevel = static_cast<uint>(logLevelIdx);
-		}
-		ImGui::TextUnformatted("Changing this requires a restart to take effect.");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Streamline logging controls the verbosity of NVIDIA Streamline backend logs. Useful for debugging issues with DLSS/DLSS-G.");
-		}
-		ImGui::Separator();
-		// FidelityFX section
-		if (ImGui::Selectable("AMD FidelityFX DLLs (click to open folder)")) {
-			ShellExecuteW(nullptr, L"open", FidelityFX::PluginDir, nullptr, nullptr, SW_SHOWNORMAL);
-		}
-		std::vector<std::string> headers = { "DLL Name", "Version" };
-		std::vector<std::vector<std::string>> ffRows;
-		for (const auto& [name, dllVersion] : FidelityFX::dllVersions)
-			ffRows.push_back({ name, dllVersion });
-		std::vector<Util::TableSortFunc> ffSorters = { nullptr, Util::VersionSortComparator };
-		Util::ShowSortedStringTableStrings(
-			"ffx_dll_versions",
-			headers,
-			ffRows,
-			0,
-			true,
-			ffSorters);
+        if (ImGui::TreeNodeEx("Backend Diagnostics")) {
+                // Streamline log level selection
+                const char* logLevels[] = { "Off", "Default", "Verbose" };
+                int logLevelIdx = static_cast<int>(settings.streamlineLogLevel);
+                if (ImGui::Combo("Streamline Logging", &logLevelIdx, logLevels, IM_ARRAYSIZE(logLevels))) {
+                        settings.streamlineLogLevel = static_cast<uint>(logLevelIdx);
+                }
+                ImGui::TextUnformatted("Changing this requires a restart to take effect.");
+                if (auto _tt = Util::HoverTooltipWrapper()) {
+                        ImGui::Text("Streamline logging controls the verbosity of NVIDIA Streamline backend logs. Useful for debugging issues with DLSS/DLSS-G.");
+                }
+                ImGui::Separator();
+                // FidelityFX section
+                if (ImGui::Selectable("AMD FidelityFX DLLs (click to open folder)")) {
+                        ShellExecuteW(nullptr, L"open", FidelityFX::PluginDir, nullptr, nullptr, SW_SHOWNORMAL);
+                }
+                std::vector<std::string> headers = { "DLL Name", "Version" };
+                std::vector<std::vector<std::string>> ffRows;
+                for (const auto& [name, dllVersion] : FidelityFX::dllVersions)
+                        ffRows.push_back({ name, dllVersion });
+                std::vector<Util::TableSortFunc> ffSorters = { nullptr, Util::VersionSortComparator };
+                Util::ShowSortedStringTableStrings(
+                        "ffx_dll_versions",
+                        headers,
+                        ffRows,
+                        0,
+                        true,
+                        ffSorters);
 
-		// Streamline section
-		if (ImGui::Selectable("NVIDIA Streamline DLLs (click to open folder)")) {
-			ShellExecuteW(nullptr, L"open", Streamline::PluginDir, nullptr, nullptr, SW_SHOWNORMAL);
-		}
-		std::vector<std::vector<std::string>> slRows;
-		for (const auto& [name, dllVersion] : Streamline::dllVersions)
-			slRows.push_back({ name, dllVersion });
-		std::vector<Util::TableSortFunc> slSorters = { nullptr, Util::VersionSortComparator };
-		Util::ShowSortedStringTableStrings(
-			"sl_dll_versions",
-			headers,
-			slRows,
-			0,
-			true,
-			slSorters);
-		ImGui::TreePop();
-	}
+                // Streamline section
+                if (ImGui::Selectable("NVIDIA Streamline DLLs (click to open folder)")) {
+                        ShellExecuteW(nullptr, L"open", Streamline::PluginDir, nullptr, nullptr, SW_SHOWNORMAL);
+                }
+                std::vector<std::vector<std::string>> slRows;
+                for (const auto& [name, dllVersion] : Streamline::dllVersions)
+                        slRows.push_back({ name, dllVersion });
+                std::vector<Util::TableSortFunc> slSorters = { nullptr, Util::VersionSortComparator };
+                Util::ShowSortedStringTableStrings(
+                        "sl_dll_versions",
+                        headers,
+                        slRows,
+                        0,
+                        true,
+                        slSorters);
+                ImGui::TreePop();
+        }
+
+        if (globals::state->IsDeveloperMode()) {
+                // Debug overlay toggle: Upscaling menu -> "Debug: Show gaze overlay".
+                ImGui::Checkbox("Debug: Show gaze overlay", &settings.debugShowGazeOverlay);
+        }
 }
 
 void Upscaling::SaveSettings(json& o_json)

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -47,16 +47,17 @@ public:
 		kDLSS
 	};
 
-	struct Settings
-	{
-		uint upscaleMethod = (uint)UpscaleMethod::kDLSS;
-		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;
-		uint qualityMode = 1;  // Default to Quality (1=Quality, 2=Balanced, 3=Performance, 4=Ultra Performance, 0=Native AA)
-		uint frameLimitMode = 1;
-		uint frameGenerationMode = 1;
-		uint frameGenerationForceEnable = 0;
-		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
-	};
+        struct Settings
+        {
+                uint upscaleMethod = (uint)UpscaleMethod::kDLSS;
+                uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;
+                uint qualityMode = 1;  // Default to Quality (1=Quality, 2=Balanced, 3=Performance, 4=Ultra Performance, 0=Native AA)
+                uint frameLimitMode = 1;
+                uint frameGenerationMode = 1;
+                uint frameGenerationForceEnable = 0;
+                uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
+                bool debugShowGazeOverlay = false;
+        };
 
 	Settings settings;
 

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -2,6 +2,8 @@
 #include "HomePageRenderer.h"
 #include "ThemeManager.h"
 
+#include <algorithm>
+#include <d3d11.h>
 #include <imgui.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
@@ -12,9 +14,71 @@
 #include "ShaderCache.h"
 #include "State.h"
 
+#include "Features/Upscaling.h"
 #include "Features/PerformanceOverlay.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "Features/VR.h"
+#include "Globals.h"
+#include "VR/GazeProvider.h"
+
+namespace
+{
+    void DrawGazeOverlay()
+    {
+        auto state = globals::state;
+        if (!state || !state->IsDeveloperMode()) {
+                return;
+        }
+
+        auto& upscaling = globals::features::upscaling;
+        if (!upscaling.settings.debugShowGazeOverlay) {
+                return;
+        }
+
+        if (!globals::game::isVR) {
+                return;
+        }
+
+        auto renderer = globals::game::renderer;
+        if (!renderer) {
+                return;
+        }
+
+        auto& renderTargets = renderer->GetRuntimeData().renderTargets;
+        auto& mainTarget = renderTargets[RE::RENDER_TARGETS::kMAIN];
+        if (!mainTarget.texture) {
+                return;
+        }
+
+        D3D11_TEXTURE2D_DESC mainDesc{};
+        mainTarget.texture->GetDesc(&mainDesc);
+        if (mainDesc.Width == 0 || mainDesc.Height == 0) {
+                return;
+        }
+
+        const float perEyeOutW = static_cast<float>(mainDesc.Width) * 0.5f;
+        const float perEyeOutH = static_cast<float>(mainDesc.Height);
+        if (perEyeOutW <= 0.0f || perEyeOutH <= 0.0f) {
+                return;
+        }
+
+        const auto gaze = GazeProvider::GetCurrentGazeUV();
+
+        const ImVec2 leftOrigin(0.0f, 0.0f);
+        const ImVec2 rightOrigin(perEyeOutW, 0.0f);
+
+        const auto toPixel = [&](const ImVec2& origin, const DirectX::XMFLOAT2& uv) {
+                return ImVec2(origin.x + uv.x * perEyeOutW, origin.y + uv.y * perEyeOutH);
+        };
+
+        const float radius = std::max(16.0f, 0.02f * perEyeOutH);
+        const ImU32 color = gaze.hasGaze ? IM_COL32(0, 255, 0, 255) : IM_COL32(255, 255, 0, 255);
+
+        auto* drawList = ImGui::GetBackgroundDrawList();
+        drawList->AddCircle(toPixel(leftOrigin, gaze.leftUV), radius, color, 0, 2.0f);
+        drawList->AddCircle(toPixel(rightOrigin, gaze.rightUV), radius, color, 0, 2.0f);
+    }
+}
 
 void OverlayRenderer::RenderOverlay(
 	Menu& menu,
@@ -190,11 +254,12 @@ void OverlayRenderer::HandleABTesting()
 
 void OverlayRenderer::FinalizeImGuiFrame()
 {
-	ImGui::Render();
-	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+        DrawGazeOverlay();
+        ImGui::Render();
+        ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 
-	if (globals::features::vr.IsOpenVRCompatible()) {
-		globals::features::vr.SubmitOverlayFrame();
+        if (globals::features::vr.IsOpenVRCompatible()) {
+                globals::features::vr.SubmitOverlayFrame();
 	}
 }
 

--- a/src/VR/GazeProvider.cpp
+++ b/src/VR/GazeProvider.cpp
@@ -1,0 +1,16 @@
+#include "VR/GazeProvider.h"
+
+namespace GazeProvider
+{
+    GazeUV GetCurrentGazeUV()
+    {
+        GazeUV gaze{};
+
+        // TODO: Integrate Varjo/OpenXR gaze runtime to populate live data.
+        gaze.hasGaze = false;
+        gaze.leftUV = { 0.5f, 0.5f };
+        gaze.rightUV = { 0.5f, 0.5f };
+
+        return gaze;
+    }
+}

--- a/src/VR/GazeProvider.h
+++ b/src/VR/GazeProvider.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <DirectXMath.h>
+
+namespace GazeProvider
+{
+    struct GazeUV
+    {
+        bool hasGaze = false;
+        DirectX::XMFLOAT2 leftUV{ 0.5f, 0.5f };
+        DirectX::XMFLOAT2 rightUV{ 0.5f, 0.5f };
+    };
+
+    GazeUV GetCurrentGazeUV();
+}


### PR DESCRIPTION
## Summary
- add a developer-only "Debug: Show gaze overlay" toggle to the Upscaling menu and persist its state
- introduce a gaze provider stub that returns normalized UV coordinates with a safe fallback
- render bright developer gaze circles on the VR atlas when the overlay toggle is enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef53665004832dbe2d63ebf47f83c9