### PR TITLE
Fix gaze overlay indentation and developer gating

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -28,7 +28,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	frameLimitMode,
 	frameGenerationMode,
 	frameGenerationForceEnable,
-	streamlineLogLevel);
+	streamlineLogLevel,
+	debugShowGazeOverlay);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -326,6 +327,11 @@ void Upscaling::DrawSettings()
 			true,
 			slSorters);
 		ImGui::TreePop();
+	}
+
+	if (globals::state->IsDeveloperMode()) {
+		// Upscaling menu -> "Debug: Show gaze overlay".
+		ImGui::Checkbox("Debug: Show gaze overlay", &settings.debugShowGazeOverlay);
 	}
 }
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -56,6 +56,7 @@ public:
 		uint frameGenerationMode = 1;
 		uint frameGenerationForceEnable = 0;
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
+		bool debugShowGazeOverlay = false;
 	};
 
 	Settings settings;

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -6,15 +6,82 @@
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
 
+#include <algorithm>
+#include <d3d11.h>
+
 #include "Feature.h"
 #include "FeatureIssues.h"
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "State.h"
 
+#include "Globals.h"
+
 #include "Features/PerformanceOverlay.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "Features/VR.h"
+
+#include "Features/Upscaling.h"
+#include "VR/GazeProvider.h"
+
+namespace
+{
+	void DrawGazeOverlay()
+	{
+		auto state = globals::state;
+		if (!state || !state->IsDeveloperMode()) {
+			return;
+		}
+
+		auto& upscaling = globals::features::upscaling;
+		if (!upscaling.settings.debugShowGazeOverlay) {
+			return;
+		}
+
+		if (!globals::game::isVR) {
+			return;
+		}
+
+		auto renderer = globals::game::renderer;
+		if (!renderer) {
+			return;
+		}
+
+		auto& renderTargets = renderer->GetRuntimeData().renderTargets;
+		auto& mainTarget = renderTargets[RE::RENDER_TARGETS::kMAIN];
+		if (!mainTarget.texture) {
+			return;
+		}
+
+		D3D11_TEXTURE2D_DESC mainDesc{};
+		mainTarget.texture->GetDesc(&mainDesc);
+		if (mainDesc.Width == 0 || mainDesc.Height == 0) {
+			return;
+		}
+
+		const float perEyeOutW = static_cast<float>(mainDesc.Width) * 0.5f;
+		const float perEyeOutH = static_cast<float>(mainDesc.Height);
+		if (perEyeOutW <= 0.0f || perEyeOutH <= 0.0f) {
+			return;
+		}
+
+		const auto gaze = GazeProvider::GetCurrentGazeUV();
+
+		const ImVec2 leftOrigin(0.0f, 0.0f);
+		const ImVec2 rightOrigin(perEyeOutW, 0.0f);
+
+		const auto toPixel = [&](const ImVec2& origin, const DirectX::XMFLOAT2& uv) {
+			return ImVec2(origin.x + uv.x * perEyeOutW, origin.y + uv.y * perEyeOutH);
+		};
+
+		const float radius = std::max(16.0f, 0.02f * perEyeOutH);
+		const ImU32 color = gaze.hasGaze ? IM_COL32(0, 255, 0, 255) : IM_COL32(255, 255, 0, 255);
+
+		auto* drawList = ImGui::GetBackgroundDrawList();
+		drawList->AddCircle(toPixel(leftOrigin, gaze.leftUV), radius, color, 0, 2.0f);
+		drawList->AddCircle(toPixel(rightOrigin, gaze.rightUV), radius, color, 0, 2.0f);
+	}
+}
 
 void OverlayRenderer::RenderOverlay(
 	Menu& menu,
@@ -190,6 +257,7 @@ void OverlayRenderer::HandleABTesting()
 
 void OverlayRenderer::FinalizeImGuiFrame()
 {
+	DrawGazeOverlay();
 	ImGui::Render();
 	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 

--- a/src/VR/GazeProvider.cpp
+++ b/src/VR/GazeProvider.cpp
@@ -1,0 +1,16 @@
+#include "VR/GazeProvider.h"
+
+namespace GazeProvider
+{
+    GazeUV GetCurrentGazeUV()
+    {
+        GazeUV gaze{};
+
+        // TODO: Integrate Varjo/OpenXR gaze runtime to populate live data.
+        gaze.hasGaze = false;
+        gaze.leftUV = { 0.5f, 0.5f };
+        gaze.rightUV = { 0.5f, 0.5f };
+
+        return gaze;
+    }
+}

--- a/src/VR/GazeProvider.h
+++ b/src/VR/GazeProvider.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <DirectXMath.h>
+
+namespace GazeProvider
+{
+    struct GazeUV
+    {
+        bool hasGaze = false;
+        DirectX::XMFLOAT2 leftUV{ 0.5f, 0.5f };
+        DirectX::XMFLOAT2 rightUV{ 0.5f, 0.5f };
+    };
+
+    GazeUV GetCurrentGazeUV();
+}


### PR DESCRIPTION
## Summary
- restore Upscaling settings serialization and menu checkbox using original indentation and developer gating
- add the gaze overlay drawing helper to the overlay renderer with the proper dependencies and background draw call

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef53665004832dbe2d63ebf47f83c9